### PR TITLE
Update noxer.py

### DIFF
--- a/noxer.py
+++ b/noxer.py
@@ -42,11 +42,17 @@ def find_nox_installation_path():
     return None
     
 #ADB Default Port of Nox Player : 62001,62025,62026
-def connect_to_nox_adb(ip='127.0.0.1', port=62001):
+def connect_to_nox_adb(ip='127.0.0.1', ports=[62001, 62025, 62026]):
     if nox_installation_path:
-        adb_command = f'\"{nox_installation_path}\\nox_adb.exe\" connect {ip}:{port}'
-        result = subprocess.run(adb_command, shell=True, text=True, capture_output=True)
-        return result.stdout.strip()
+        for port in ports:
+            adb_command = f'\"{nox_installation_path}\\nox_adb.exe\" connect {ip}:{port}'
+            result = subprocess.run(adb_command, shell=True, text=True, capture_output=True)
+            if 'connected' in result.stdout.lower():
+                return result.stdout.strip()
+            elif 'failed' in result.stdout.lower():
+                continue
+
+        return "No port available for connection."
     else:
         return "Nox player not installed."
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 psutil
 pyOpenSSL
 Requests
+frida-tools


### PR DESCRIPTION
## Enhance Nox ADB Connection Logic to Support Multiple Ports

**Description:**

This pull request modifies the `connect_to_nox_adb` function to attempt connections on a list of predefined ports, rather than a single hardcoded or user-specified port. This enhancement increases the robustness of the connection process, as it can automatically find an available Nox instance if multiple instances are running or if the default port is occupied.

**Changes Made:**

- **Modified Function Signature:**
    - The `port` parameter in `connect_to_nox_adb` has been changed to `ports`.
    - `ports` now accepts a list of integers (defaulting to `[62001, 62025, 62026]`) instead of a single integer.
- **Iterative Connection Attempts:**
    - The function now iterates through the provided `ports` list.
    - For each port, it attempts to establish an ADB connection using the `nox_adb.exe` command.
- **Connection Success Check:**
    - After each connection attempt, the `stdout` of the `subprocess.run` command is checked.
    - If the output contains the string "connected" (case-insensitive), the function immediately returns the success message.
- **Connection Failure Handling:**
    - If the output contains the string "failed" (case-insensitive), the function continues to the next port in the list.
- **No Available Port Message:**
    - If all ports in the list are attempted and none result in a successful connection, the function returns "No port available for connection."
- **Retained Original Behavior:**
    - The check for `nox_installation_path` remains, returning "Nox player not installed." if the path is not found.

**Reason for Change:**

The original implementation could only connect to a single specified port. If that port was not the correct one for the desired Nox instance or if it was in use, the connection would fail. This change allows the script to automatically try common Nox ADB ports, improving the likelihood of a successful connection without manual port specification in many common scenarios.

**Original Code:**

```python
def connect_to_nox_adb(ip='127.0.0.1', port=62001):
    if nox_installation_path:
        adb_command = f'\"{nox_installation_path}\\nox_adb.exe\" connect {ip}:{port}'
        result = subprocess.run(adb_command, shell=True, text=True, capture_output=True)
        return result.stdout.strip()
    else:
        return "Nox player not installed."